### PR TITLE
default constructor added to PgDbContext 

### DIFF
--- a/Sample/Services/Admin.Service/Data/ServiceDbContext.cs
+++ b/Sample/Services/Admin.Service/Data/ServiceDbContext.cs
@@ -3,7 +3,6 @@ using Admin.Service.Features.Tenants.Entities;
 
 using Microsoft.EntityFrameworkCore;
 
-using Yaver.App;
 using Yaver.Db;
 
 namespace Admin.Service.Data;
@@ -11,37 +10,16 @@ namespace Admin.Service.Data;
 public class ServiceDbContext : InMemoryDbContext {
   private const string Schema = "multitenancy";
 
-  public ServiceDbContext(IConfiguration configuration, IAuditMetadata auditMetadata)
-    : base(auditMetadata.AuditInfo.UserId) {
-    var connectionString = configuration.GetSection("ConnectionString").Value;
-  }
 
-
-  public DbSet<DatabaseServer> DatabaseServers { get; set; }
-  public DbSet<Tenant> Tenants { get; set; }
+  public DbSet<DatabaseServer> DatabaseServers { get; init; }
+  public DbSet<Tenant> Tenants { get; init; }
 
 
   protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
     optionsBuilder.UseInMemoryDatabase(Schema);
-    // base.OnConfiguring(optionsBuilder);
-    // var connStr = _configuration.GetSection("MainDbConnectionString").Value;
-
-    // _logger.LogInformation($"mainDbConn: {connStr}");
-    // if (!optionsBuilder.IsConfigured) {
-    // 	optionsBuilder.UseNpgsql(
-    // 			connStr,
-    // 			b => {
-    // 				b.MigrationsAssembly("Admin.Service.App");
-    // 				b.MigrationsHistoryTable("__EFMigrationsHistory", Schema);
-    // 			}
-    // 	);
-    // }
   }
 
   protected override void OnModelCreating(ModelBuilder builder) {
-    // base.OnModelCreating(builder);
-
-    // builder.HasDefaultSchema(Schema);
     builder.ApplyConfiguration(new DatabaseServerEntityTypeConfiguration());
   }
 }

--- a/Sample/Services/Admin.Service/Program.cs
+++ b/Sample/Services/Admin.Service/Program.cs
@@ -13,26 +13,16 @@ builder.AddYaverLogger();
 
 // Accept only HTTP/2 to allow insecure connections for development.
 // builder.WebHost.ConfigureKestrel(o => o.ListenAnyIP(6000, c => c.Protocols = HttpProtocols.Http2));
-builder.AddHandlerServer(
-  options => {
-    // options.Interceptors.Add<ServerLogInterceptor>();
-    options.Interceptors.Add<ServerFeaturesInterceptor>();
-  });
+builder.AddHandlerServer(options => { options.Interceptors.Add<ServerFeaturesInterceptor>(); });
 
 builder.Services.AddScoped<IRequestMetadata, RequestMetadata>();
 builder.Services.AddScoped<IAuditMetadata, AuditMetadata>();
-// builder.Services.AddScoped<ITenantMetadata, TenantMetadata>();
 
 builder.Services.AddDbContext<ServiceDbContext>();
 
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
-
-//from lib
-// builder.Services.AddRpcCommandHandlers();
-// builder.Services.AddValidator<IdRequestValidator>();
-
 
 builder.Services.AddLocalization();
 builder.Services.Configure<RequestLocalizationOptions>(options => {
@@ -45,28 +35,12 @@ builder.Services.AddSingleton<IStringLocalizerFactory, JsonStringLocalizerFactor
 builder.Services.AddDistributedMemoryCache();
 
 
-// builder.Services.AddSingleton<IStringLocalizerFactory>(new JsonStringLocalizerFactory());
-
-
 var app = builder.Build();
 app.UseRequestLocalization();
 
-// app.MapRpcCommandHandlers();
 app.RegisterRpcCommandHandlers();
 
-var context = new ServiceDbContext(app.Configuration,
-  new AuditMetadata(
-    new AuditInfo(
-      UserId: Guid.NewGuid(),
-      UserName: string.Empty,
-      Email: string.Empty,
-      GivenName: string.Empty,
-      FamilyName: string.Empty,
-      Roles: []
-    )
-  )
-);
-
+var context = new ServiceDbContext();
 
 context.Database.EnsureCreated();
 

--- a/Src/Db.Core/LinqHelper.cs
+++ b/Src/Db.Core/LinqHelper.cs
@@ -3,75 +3,144 @@ using System.Reflection;
 
 using Microsoft.EntityFrameworkCore;
 
-// ReSharper disable once CheckNamespace
 namespace Yaver.Db;
 
 /// <summary>
-///   Provides helper methods for LINQ expressions and filters.
+///   Provides helper methods for building LINQ expressions and dynamic filtering, 
+///   including support for searching, ordering, and building property chains.
 /// </summary>
+/// <remarks>
+///   The <see cref="LinqHelper"/> class includes methods designed to simplify complex 
+///   LINQ operations, such as dynamically constructing property chains and generating 
+///   filter expressions for advanced queries.
+///   
+///   <list type="bullet">
+///     <item>
+///       <description>
+///         <see cref="BuildExpressionFromPropertyChain"/> - Dynamically constructs an expression tree 
+///         from a string representing a property chain, enabling flexible property access in LINQ queries.
+///       </description>
+///     </item>
+///     <item>
+///       <description>
+///         <see cref="BuildFilter{T}"/> - Generates a LINQ expression for filtering by a search term 
+///         across specified properties, supporting different data types including enums and primitives.
+///       </description>
+///     </item>
+///   </list>
+/// </remarks>
+/// <example>
+///   <code>
+///     var filter = LinqHelper.BuildFilter&lt;Product&gt;("widget", new[] { "Name", "Category" });
+///     var results = dbContext.Products.Where(filter).ToList();
+///   </code>
+/// </example>
 public static class LinqHelper {
-  /// <summary>
-  ///   Builds an expression tree from a property chain string for a given type.
-  /// </summary>
-  /// <param name="T">The type to build the expression for.</param>
-  /// <param name="boundExpression">The expression to bind the property chain to.</param>
-  /// <param name="propertyName">The property chain string.</param>
-  /// <returns>The expression tree representing the property chain.</returns>
-  public static Expression? BuildExpressionFromPropertyChain(
-    Type T,
-    Expression boundExpression,
-    string propertyName) {
-    var propertyNameChain = propertyName.Split(".");
-    var remainingChain = propertyNameChain.Skip(1).ToArray();
-
-    var property = T.GetProperty(propertyNameChain[0],
-      BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-    if (property == null) {
-      return null;
-    }
-
-    var expression = Expression.Property(boundExpression, property);
-
-    return remainingChain.Length > 0
-      ? BuildExpressionFromPropertyChain(property.PropertyType, expression, string.Join(".", remainingChain))
-      : expression;
-  }
-
-  // Generic filter builder. TODO: Could be moved to more appropriate extension class.
-  /// <summary>
-  ///   Builds a filter expression for the specified search term and fields.
-  /// </summary>
-  /// <typeparam name="T">The type of entity to filter.</typeparam>
-  /// <param name="term">The search term to filter by.</param>
-  /// <param name="fields">The fields to search for the search term.</param>
-  /// <returns>An expression that filters entities based on the search term and fields.</returns>
-  public static Expression<Func<T, bool>> BuildFilter<T>(string term, string[] fields) {
-    Expression filterBody = Expression.Constant(false);
-
-    var efLikeMethod = typeof(DbFunctionsExtensions).GetMethod("Like",
+  // Holds a reference to the EF Core 'Like' method used for building filter expressions.
+  private static readonly MethodInfo _efLikeMethod = typeof(DbFunctionsExtensions)
+    .GetMethod(
+      "Like",
       BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
       null,
-      [typeof(DbFunctions), typeof(string), typeof(string)],
-      null);
-    var pattern = Expression.Constant($"%{term}%", typeof(string));
+      [
+        typeof(DbFunctions),
+        typeof(string),
+        typeof(string)
+      ],
+      null
+    )!;
 
+  /// <summary>
+  ///   Builds a LINQ expression to filter entities of a given type based on a search term across specified fields.
+  /// </summary>
+  /// <typeparam name="T">The type of the entity to filter.</typeparam>
+  /// <param name="term">The search term used to filter the entities.</param>
+  /// <param name="fields">
+  ///   An array of field names (as strings) representing the properties of the entity type <typeparamref name="T"/> 
+  ///   that will be searched against the search term.
+  /// </param>
+  /// <returns>
+  ///   A <see cref="Func{T, Boolean}"/> expression that filters the entities of type <typeparamref name="T"/> 
+  ///   based on whether any of the specified fields match the search term.
+  /// </returns>
+  /// <remarks>
+  ///   This method constructs an OR-based filter expression that can be used with LINQ methods 
+  ///   such as <see cref="Queryable.Where{TSource}(IQueryable{TSource}, Expression{Func{TSource, Boolean}})"/>. 
+  ///   Each field in the <paramref name="fields"/> array is checked using a case-insensitive LIKE pattern 
+  ///   to see if it contains the search term.
+  /// </remarks>
+  public static Expression<Func<T, bool>> BuildFilter<T>(string term, string[] fields) {
+    Expression filterBody = Expression.Constant(false);
     var parameterExpression = Expression.Parameter(typeof(T), "entity");
 
     foreach (var field in fields) {
       var fieldExpression = BuildExpressionFromPropertyChain(typeof(T), parameterExpression, field);
 
-      if (efLikeMethod != null) {
-        var fieldFilter = Expression.Call(
-          efLikeMethod,
-          Expression.Property(null, typeof(EF), nameof(EF.Functions)),
-          fieldExpression,
-          pattern
-        );
+      var propertyType = fieldExpression is MemberExpression memberExpression
+        ? ((PropertyInfo)memberExpression.Member).PropertyType
+        : null;
 
+      if (propertyType == null) continue;
+
+      var fieldFilter = propertyType switch {
+        not null when propertyType == typeof(string) => (Expression)Expression.Call(
+          _efLikeMethod!,
+          Expression.Property(null, typeof(EF), nameof(EF.Functions)),
+          fieldExpression!,
+          Expression.Constant($"%{term}%", typeof(string))
+        ),
+        not null when propertyType == typeof(int) && int.TryParse(term, out var intValue) =>
+          Expression.Equal(fieldExpression!, Expression.Constant(intValue)),
+        not null when propertyType == typeof(bool) && bool.TryParse(term, out var boolValue) =>
+          Expression.Equal(fieldExpression!, Expression.Constant(boolValue)),
+        { IsEnum: true } when Enum.TryParse(propertyType, term, true, out var enumValue) =>
+          Expression.Equal(fieldExpression!, Expression.Constant(enumValue)),
+        _ => null
+      };
+
+      if (fieldFilter != null) {
         filterBody = Expression.OrElse(filterBody, fieldFilter);
       }
     }
 
     return Expression.Lambda<Func<T, bool>>(filterBody, parameterExpression);
+  }
+
+
+  /// <summary>
+  /// Builds an expression tree that represents accessing a specified property chain
+  /// on a given type. This enables dynamically building expressions for nested properties
+  /// using a dot-separated property name string.
+  /// </summary>
+  /// <param name="type">The type to start from, where the property chain begins.</param>
+  /// <param name="boundExpression">The initial expression to which the property chain is bound.</param>
+  /// <param name="propertyName">The dot-separated property chain string (e.g., "Parent.Child.Property").</param>
+  /// <returns>
+  /// An <see cref="Expression"/> that represents the property chain access, or <c>null</c> 
+  /// if any property in the chain does not exist.
+  /// </returns>
+  /// <remarks>
+  /// This method uses reflection to access each property in the chain, allowing for
+  /// complex, nested property access in dynamically generated LINQ expressions.
+  /// </remarks>
+  public static Expression? BuildExpressionFromPropertyChain(
+    Type type,
+    Expression boundExpression,
+    string propertyName
+  ) {
+    var propertyNameChain = propertyName.Split(".");
+    var expression = boundExpression;
+
+    foreach (var property in propertyNameChain) {
+      var propInfo = type.GetProperty(property, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+      if (propInfo == null) {
+        return null; // Property chain is invalid
+      }
+
+      expression = Expression.Property(expression, propInfo);
+      type = propInfo.PropertyType; // Update type for the next property in the chain
+    }
+
+    return expression;
   }
 }

--- a/Src/Db.InMemory/InMemoryDbContext.cs
+++ b/Src/Db.InMemory/InMemoryDbContext.cs
@@ -3,7 +3,23 @@
 namespace Yaver.Db;
 
 /// <summary>
-///   Represents an in-memory database context for the current user.
+///   Represents an in-memory database context for temporary and testing purposes.
 /// </summary>
-public class InMemoryDbContext(DbContextOptions options) : DbContext(options) {
+/// <remarks>
+///   This context is intended for use with in-memory data storage, typically in scenarios such as
+///   unit testing or temporary data management, without the need for a persistent database.
+/// </remarks>
+public class InMemoryDbContext : DbContext {
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="InMemoryDbContext"/> class with default options.
+  /// </summary>
+  protected InMemoryDbContext() : base(new DbContextOptions<InMemoryDbContext>()) {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="InMemoryDbContext"/> class with the specified options.
+  /// </summary>
+  /// <param name="options">The options to configure the context.</param>
+  public InMemoryDbContext(DbContextOptions options) : base(options) {
+  }
 }

--- a/Src/Db.PostgreSQL/PgDbContext.cs
+++ b/Src/Db.PostgreSQL/PgDbContext.cs
@@ -6,11 +6,18 @@ namespace Yaver.Db;
 ///   Represents a PostgreSQL database context with additional configuration for case-insensitive text search.
 /// </summary>
 /// <remarks>
-///   This context inherits from <see cref="BaseDbContext" /> and adds configuration for case-insensitive text search
+///   This context inherits from <see cref="DbContext" /> and adds configuration for case-insensitive text search
 ///   by setting the column type of all string properties to "citext" and enabling the "citext" extension.
 /// </remarks>
-/// <seealso cref="BaseDbContext" />
-public class PgDbContext(DbContextOptions options) : DbContext(options) {
+/// <seealso cref="DbContext" />
+public class PgDbContext : DbContext {
+  /// <inheritdoc />
+  protected PgDbContext() : base(new DbContextOptions<DbContext>()) {
+  }
+
+  /// <inheritdoc />
+  public PgDbContext(DbContextOptions options) : base(options) {
+  }
 
   /// <summary>
   ///   Override this method to further configure the model that was discovered by convention from the entity types
@@ -20,8 +27,8 @@ public class PgDbContext(DbContextOptions options) : DbContext(options) {
   /// <param name="builder">The builder being used to construct the model for this context.</param>
   protected override void OnModelCreating(ModelBuilder builder) {
     base.OnModelCreating(builder);
-    builder
-      .HasPostgresExtension("citext");
+    
+    builder.HasPostgresExtension("citext");
 
     foreach (var e in builder.Model.GetEntityTypes()) {
       foreach (var prop in e.GetProperties().Where(p => p.ClrType == typeof(string))) {
@@ -30,35 +37,40 @@ public class PgDbContext(DbContextOptions options) : DbContext(options) {
     }
   }
 
+  /// <summary>
+  /// Generates uuid_generate_v7 funtion on the database
+  /// </summary>
   public void GenerateUuidV7Function() {
     using var command = Database.GetDbConnection().CreateCommand();
 
     //https://gist.githubusercontent.com/kjmph/5bd772b2c2df145aa645b837da7eca74/raw/db903fb49a01380e3791f9893e4a8f62c1dd3085/A_UUID_v7_for_Postgres.sql
-    command.CommandText = @"
-    create or replace function uuid_generate_v7()
-    returns uuid
-    as $$
-    begin
-      -- use random v4 uuid as starting point (which has the same variant we need)
-      -- then overlay timestamp
-      -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
-      return encode(
-        set_bit(
-          set_bit(
-            overlay(uuid_send(gen_random_uuid())
-                    placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
-                    from 1 for 6
-            ),
-            52, 1
-          ),
-          53, 1
-        ),
-        'hex')::uuid;
-    end
-    $$
-    language plpgsql
-    volatile;
-    ";
+    command.CommandText = $"""
+                           
+                               create or replace function uuid_generate_v7()
+                               returns uuid
+                               as $$
+                               begin
+                                 -- use random v4 uuid as starting point (which has the same variant we need)
+                                 -- then overlay timestamp
+                                 -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+                                 return encode(
+                                   set_bit(
+                                     set_bit(
+                                       overlay(uuid_send(gen_random_uuid())
+                                               placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                                               from 1 for 6
+                                       ),
+                                       52, 1
+                                     ),
+                                     53, 1
+                                   ),
+                                   'hex')::uuid;
+                               end
+                               $$
+                               language plpgsql
+                               volatile;
+                               
+                           """;
 
     Database.OpenConnection();
 


### PR DESCRIPTION
with this we can configure connection on onConfiguring override not strictly on constructor.

linq helper class has been improved, and it accepts int, bool and enum types as term without breaking and changing anything.

also I have fixed sample project and in memory sample db context