### PR TITLE
Refactor to support distributed and in-memory JSON localizers

### DIFF
--- a/Sample/Services/Admin.Service/Program.cs
+++ b/Sample/Services/Admin.Service/Program.cs
@@ -31,7 +31,7 @@ builder.Services.Configure<RequestLocalizationOptions>(options => {
     .AddSupportedCultures(supportedCultures)
     .AddSupportedUICultures(supportedCultures);
 });
-builder.Services.AddSingleton<IStringLocalizerFactory, JsonStringLocalizerFactory>();
+builder.Services.AddSingleton<IStringLocalizerFactory, InMemoryJsonStringLocalizerFactory>();
 builder.Services.AddDistributedMemoryCache();
 
 

--- a/Src/App.Core/[Localizer]/DistributedCacheJsonStringLocalizer.cs
+++ b/Src/App.Core/[Localizer]/DistributedCacheJsonStringLocalizer.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Localization;
+
+namespace Yaver.App;
+
+/// <summary>
+/// Implements a distributed cache-based string localizer that uses JSON files as the resource source.
+/// This implementation combines the benefits of distributed caching with JSON-based localization,
+/// providing efficient and scalable string localization across multiple application instances.
+/// </summary>
+public class DistributedCacheJsonStringLocalizer(IDistributedCache cache) : IStringLocalizer {
+  private readonly IDistributedCache _cache = cache;
+  private readonly JsonSerializerOptions _serializerOptions = new();
+
+  /// <summary>
+  /// Retrieves a localized string for the specified resource name.
+  /// First checks the distributed cache, then falls back to the JSON resource file if not found.
+  /// </summary>
+  /// <param name="name">The resource name/key to localize.</param>
+  /// <returns>
+  /// A <see cref="LocalizedString"/> containing the localized value. If the resource is not found,
+  /// returns the original name and sets <see cref="LocalizedString.ResourceNotFound"/> to true.
+  /// </returns>
+  public LocalizedString this[string name] {
+    get {
+      var value = GetString(name);
+      return new LocalizedString(name, value ?? name, value == null);
+    }
+  }
+
+  /// <summary>
+  /// Retrieves a localized string and formats it with the provided arguments.
+  /// Supports composite format strings with placeholders for dynamic content.
+  /// </summary>
+  /// <param name="name">The resource name/key to localize.</param>
+  /// <param name="arguments">Variable number of arguments to format the localized string.</param>
+  /// <returns>
+  /// A formatted <see cref="LocalizedString"/>. If the resource is not found,
+  /// returns the original name and sets <see cref="LocalizedString.ResourceNotFound"/> to true.
+  /// </returns>
+  public LocalizedString this[string name, params object[] arguments] {
+    get {
+      var actualValue = this[name];
+      return !actualValue.ResourceNotFound
+          ? new LocalizedString(name, string.Format(actualValue.Value, arguments), false)
+          : actualValue;
+    }
+  }
+
+  /// <summary>
+  /// Retrieves all localized strings for the current culture from the JSON resource file.
+  /// This method reads the entire JSON file and returns all key-value pairs as localized strings.
+  /// </summary>
+  /// <param name="includeParentCultures">Whether to include strings from parent cultures in the result.</param>
+  /// <returns>An enumerable collection of all <see cref="LocalizedString"/> objects for the current culture.</returns>
+  public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) {
+    var filePath = $"i18n/{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName}.json";
+    using var str = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+    using var doc = JsonDocument.Parse(str);
+    var root = doc.RootElement;
+    foreach (var prop in root.EnumerateObject()) {
+      yield return new LocalizedString(prop.Name, prop.Value.GetString(), false);
+    }
+  }
+
+  /// <summary>
+  /// Retrieves a localized string value using a two-level caching strategy:
+  /// 1. First checks the distributed cache for the value
+  /// 2. If not found in cache, reads from the JSON file and updates the cache
+  /// </summary>
+  /// <param name="key">The resource key to look up.</param>
+  /// <returns>The localized string value if found, null otherwise.</returns>
+  private string? GetString(string key) {
+    var relativeFilePath = $"i18n/{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName}.json";
+    var fullFilePath = Path.GetFullPath(relativeFilePath);
+    if (File.Exists(fullFilePath)) {
+      var cacheKey = $"locale_{Thread.CurrentThread.CurrentCulture.Name}_{key}";
+      var cacheValue = _cache.GetString(cacheKey);
+      if (!string.IsNullOrEmpty(cacheValue)) {
+        return cacheValue;
+      }
+
+      var result = GetValueFromJSON(key, Path.GetFullPath(relativeFilePath));
+
+      if (!string.IsNullOrEmpty(result)) {
+        _cache.SetString(cacheKey, result);
+      }
+      return result;
+    }
+    return default;
+  }
+
+  /// <summary>
+  /// Extracts a specific value from a JSON resource file.
+  /// This method handles the low-level JSON parsing and property extraction.
+  /// </summary>
+  /// <param name="propertyName">The name of the property to extract from the JSON file.</param>
+  /// <param name="filePath">The absolute path to the JSON resource file.</param>
+  /// <returns>The string value of the property if found, null otherwise.</returns>
+  private static string? GetValueFromJSON(string propertyName, string filePath) {
+    if (propertyName == null || filePath == null) {
+      return default;
+    }
+
+    using var str = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+    using var doc = JsonDocument.Parse(str);
+    var root = doc.RootElement;
+
+    if (root.TryGetProperty(propertyName, out var property)) {
+      return property.GetString();
+    }
+
+    return default;
+  }
+}

--- a/Src/App.Core/[Localizer]/DistributedCacheJsonStringLocalizerFactory.cs
+++ b/Src/App.Core/[Localizer]/DistributedCacheJsonStringLocalizerFactory.cs
@@ -4,20 +4,20 @@ using Microsoft.Extensions.Localization;
 namespace Yaver.App;
 
 /// <summary>
-/// Represents a factory for creating instances of <see cref="JsonStringLocalizer"/>.
+/// Represents a factory for creating instances of <see cref="DistributedCacheJsonStringLocalizer"/>.
 /// </summary>
-public class JsonStringLocalizerFactory(IDistributedCache cache) : IStringLocalizerFactory {
+public class DistributedCacheJsonStringLocalizerFactory(IDistributedCache cache) : IStringLocalizerFactory {
   private readonly IDistributedCache _cache = cache;
 
   /// <summary>
   /// Represents a service that provides localized strings for an application.
   /// </summary>
   public IStringLocalizer Create(Type resourceSource) =>
-      new JsonStringLocalizer(_cache);
+      new DistributedCacheJsonStringLocalizer(_cache);
 
   /// <summary>
   /// Represents a service that provides localized strings for an application.
   /// </summary>
   public IStringLocalizer Create(string baseName, string location) =>
-     new JsonStringLocalizer(_cache);
+     new DistributedCacheJsonStringLocalizer(_cache);
 }

--- a/Src/App.Core/[Localizer]/InMemoryJsonStringLocalizer.cs
+++ b/Src/App.Core/[Localizer]/InMemoryJsonStringLocalizer.cs
@@ -1,15 +1,12 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 
-using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 
 namespace Yaver.App;
 
-/// <summary>
-/// Provides string localization using JSON files as the resource source.
-/// </summary>
-public class JsonStringLocalizer(IDistributedCache cache) : IStringLocalizer {
-  private readonly IDistributedCache _cache = cache;
+public class InMemoryJsonStringLocalizer(IMemoryCache cache) : IStringLocalizer {
+  private readonly IMemoryCache _cache = cache;
   private readonly JsonSerializerOptions _serializerOptions = new();
 
   /// <summary>
@@ -68,7 +65,7 @@ public class JsonStringLocalizer(IDistributedCache cache) : IStringLocalizer {
     var fullFilePath = Path.GetFullPath(relativeFilePath);
     if (File.Exists(fullFilePath)) {
       var cacheKey = $"locale_{Thread.CurrentThread.CurrentCulture.Name}_{key}";
-      var cacheValue = _cache.GetString(cacheKey);
+      var cacheValue = _cache.Get<string>(cacheKey);
       if (!string.IsNullOrEmpty(cacheValue)) {
         return cacheValue;
       }
@@ -76,7 +73,7 @@ public class JsonStringLocalizer(IDistributedCache cache) : IStringLocalizer {
       var result = GetValueFromJSON(key, Path.GetFullPath(relativeFilePath));
 
       if (!string.IsNullOrEmpty(result)) {
-        _cache.SetString(cacheKey, result);
+        _cache.Set<string>(cacheKey, result);
       }
       return result;
     }

--- a/Src/App.Core/[Localizer]/InMemoryJsonStringLocalizerFactory.cs
+++ b/Src/App.Core/[Localizer]/InMemoryJsonStringLocalizerFactory.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Localization;
+
+namespace Yaver.App;
+
+public class InMemoryJsonStringLocalizerFactory(IMemoryCache cache)  : IStringLocalizerFactory {
+  private readonly IMemoryCache _cache = cache;
+
+  /// <summary>
+  /// Represents a service that provides localized strings for an application.
+  /// </summary>
+  public IStringLocalizer Create(Type resourceSource)
+    => new InMemoryJsonStringLocalizer(_cache);
+
+  /// <summary>
+  /// Represents a service that provides localized strings for an application.
+  /// </summary>
+  public IStringLocalizer Create(string baseName, string location)
+    => new InMemoryJsonStringLocalizer(_cache);
+}


### PR DESCRIPTION
Replaced `JsonStringLocalizer` with `DistributedCacheJsonStringLocalizer` and added `InMemoryJsonStringLocalizer` for flexibility in localization approaches. Updated dependency injection in `Admin.Service` to use `InMemoryJsonStringLocalizerFactory`.